### PR TITLE
Add version field to /health route

### DIFF
--- a/src/__tests__/health.test.ts
+++ b/src/__tests__/health.test.ts
@@ -26,5 +26,10 @@ describe('Health Check Route', () => {
       const response = await request(app).get('/health');
       expect(response.headers['content-type']).toMatch(/json/);
     });
+
+    it('should return version v1.0.0', async () => {
+      const response = await request(app).get('/health');
+      expect(response.body.version).toBe('v1.0.0');
+    });
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ app.get('/', (req: Request, res: Response) => {
 });
 
 app.get('/health', (req: Request, res: Response) => {
-  res.json({ status: 'healthy', timestamp: new Date().toISOString() });
+  res.json({ status: 'healthy', timestamp: new Date().toISOString(), version: 'v1.0.0' });
 });
 
 export default app;


### PR DESCRIPTION
This PR adds a version field to the /health route response.

Changes:
- Added version: 'v1.0.0' to the /health endpoint response
- Added corresponding test to verify the version field

Closes #17